### PR TITLE
Direct Support FTE is optional

### DIFF
--- a/plan/proposal_summary.md
+++ b/plan/proposal_summary.md
@@ -7,7 +7,9 @@ Goal Target to Start Resource Requirements Funding Requirements
 ## 1. [Understand the Problem Space](https://github.com/ossf/SIRT/blob/main/plan/1.0%20Understand%20the%20Problem%20Space.md)
 
 ### Time & Resource Estimate
+
 #### YEAR 1
+
 | Milestone | Estimated Volunteers | Estimated Total Hours | Estimated FTEs/Expenses | Stage |
 | :-------: | :------------------: | :-------------------: | :---------------------: | :---: |
 | G1.1      |         >3           |          20- 41       |           xx            | ➡️ Y1 |
@@ -24,7 +26,9 @@ Goal Target to Start Resource Requirements Funding Requirements
 ## 2. [Identify Core Services](https://github.com/ossf/SIRT/blob/main/plan/2.0%20Identify%20Core%20Services%20and%20Processes.md)
 
 ### Time & Resource Estimate
+
 #### YEAR 1
+
 | Milestone | Estimated Volunteers | Estimated Total Hours | Estimated FTEs/Expenses | Stage |
 | :-------: | :------------------: | :-------------------: | :---------------------: | :---: |
 | G2.1      |         4-5          |          20-25        |           xx           | ➡️ Y1 |
@@ -34,6 +38,7 @@ Goal Target to Start Resource Requirements Funding Requirements
 | G2.4.2    |         >8           |          280-680      |           xx           | ➡️ Y1 |
 
 #### YEAR 2
+
 | Milestone | Estimated Volunteers | Estimated Total Hours | Estimated FTEs/Expenses | Stage |
 | :-------: | :------------------: | :-------------------: | :---------------------: | :---: |
 | G2.2      |         >5           |          40-50        |           xx           | ➡️ Y2 |
@@ -48,7 +53,9 @@ Goal Target to Start Resource Requirements Funding Requirements
 ## 3. [Execution](https://github.com/ossf/SIRT/blob/main/plan/3.0%20Execution.md)
 
 ### Time & Resource Estimate
+
 #### YEAR 1
+
 | Milestone | Estimated Volunteers | Estimated Total Hours | Estimated FTEs/Expenses | Stage |
 | :-------: | :------------------: | :-------------------: | :---------------------: | :---: |
 | G3.1      |         >5           |          72-84        |     1 Pgm $300K annual  | ➡️ Y1 |
@@ -75,7 +82,9 @@ Goal Target to Start Resource Requirements Funding Requirements
 > - Tooling Costs (TBD)
 
 ---
+
 ## Risks and Challenges
+
 > - Community may be slow in uptake of OSS-SIRT's services
 > - Community may not accept OSS-SIRT's services
 > - Community response may be greater than anticipated

--- a/plan/proposal_summary.md
+++ b/plan/proposal_summary.md
@@ -51,7 +51,7 @@ Goal Target to Start Resource Requirements Funding Requirements
 #### YEAR 1
 | Milestone | Estimated Volunteers | Estimated Total Hours | Estimated FTEs/Expenses | Stage |
 | :-------: | :------------------: | :-------------------: | :---------------------: | :---: |
-| G3.1      |         >5           |          72-84        |     I Pgm $300K annual  | ➡️ Y1 |
+| G3.1      |         >5           |          72-84        |     1 Pgm $300K annual  | ➡️ Y1 |
 | G2.2      |         >5           |          152-200      |     Tool cost TBD       | ➡️ Y1 |
 | G3.3      |         >5           |          68-83        |           xx            | ➡️ Y1 |
 | G3.4      |         >5           |          196-245      |           xx            | ➡️ Y1 |
@@ -60,17 +60,19 @@ Goal Target to Start Resource Requirements Funding Requirements
 
 > - Estimated # Volunteers:5
 > - Estimated Total Combined Volunteer Hours: Y1 578-716
+> - Estimated FTE: 1 (optionally 2)
 >   - 1 FTE OSS-SIRT Program Management - $300,000
->   - 1 FTE OSS-SIRT Direct Services - $300,000 [^1]
->   - Tooling Costs (TBD)
+>   - 1 FTE OSS-SIRT Direct Services - $300,000, optional[^1]
+> - Tooling Costs (TBD)
 
 ## TOTAL
 
 > - Estimated # Volunteers: 8
 > - Estimated Total Combined Volunteer Hours:  1,720 - 2,926
+> - Estimated FTE: 1 (optionally 2)
 >   - 1 FTE OSS-SIRT Program Management - $300,000
->   - 1 FTE OSS-SIRT Direct Services - $300,000 [^1]
->   - Tooling Costs (TBD)
+>   - 1 FTE OSS-SIRT Direct Services - $300,000, optional[^1]
+> - Tooling Costs (TBD)
 
 ---
 ## Risks and Challenges
@@ -83,4 +85,4 @@ Goal Target to Start Resource Requirements Funding Requirements
 
 ---
 Footnotes:
-[^1]: The Direct Services position provides the minimum level of operational support and is not explicitly defined in the plan details. Effort provided by position would be counted against Volunteer effort under [3. Execution](proposal_summary.md#3-execution).
+[^1]: The Direct Services position is optional and not explicitly described in the plan details. The position is intended to provide a minimum level of operational support and continuity to mitigate potential variability in Volunteer efforts. Effort provided by position would be counted against Volunteer effort under [3. Execution](proposal_summary.md#3-execution) and hiring effort would be equivalent to that described in [3.1 Hire Program Manager for OSS-SIRT](3.0%20Execution.md#31-hire-program-manager-for-oss-sirt).


### PR DESCRIPTION
Make Direct Services/operational support FTE optional and intended as a tradeoff to hedge against volunteer variability

Signed-off-by: Art Manion <zmanion@protonmail.com>